### PR TITLE
CO: Fixed bug that erases current customization fields

### DIFF
--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -456,13 +456,21 @@ class AdminProductWrapper
      */
     public function processProductCustomization($product, $data)
     {
+        $customization_ids = array();
+        if ($data) {
+            foreach ($data as $customization) {
+                $customization_ids[] = (int)$customization['id_customization_field'];
+            }
+        }
+
         //remove customization field langs
         foreach ($product->getCustomizationFieldIds() as $customizationFiled) {
             \Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'customization_field_lang WHERE `id_customization_field` = '.(int)$customizationFiled['id_customization_field']);
         }
 
-        //remove customization for the product
-        \Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'customization_field WHERE `id_product` = '.(int)$product->id);
+        //remove unused customization for the product
+        \Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'customization_field WHERE 
+            `id_product` = '.(int)$product->id.' AND `id_customization_field` NOT IN ('.implode(",", $customization_ids).')');
 
         //create new customizations
         $countFieldText = 0;
@@ -478,10 +486,17 @@ class AdminProductWrapper
                 }
 
                 //create label
-                \Db::getInstance()->execute('INSERT INTO `'._DB_PREFIX_.'customization_field` (`id_product`, `type`, `required`)
-                    VALUES ('.(int)$product->id.', '.(int)$customization['type'].', '.($customization['require'] ? 1 : 0).')');
-
-                $id_customization_field = (int)\Db::getInstance()->Insert_ID();
+                if (isset($customization['id_customization_field'])) {
+                    $id_customization_field = (int)$customization['id_customization_field'];
+                    \Db::getInstance()->execute('UPDATE `'._DB_PREFIX_.'customization_field`
+					SET `required` = ' . ($customization['require'] ? 1 : 0) . ', `type` = ' . (int)$customization['type'] . '
+					WHERE `id_customization_field` = '.$id_customization_field);
+                } else {
+	                \Db::getInstance()->execute('INSERT INTO `'._DB_PREFIX_.'customization_field` (`id_product`, `type`, `required`)
+	                    VALUES ('.(int)$product->id.', '.(int)$customization['type'].', '.($customization['require'] ? 1 : 0).')');
+	
+	                $id_customization_field = (int)\Db::getInstance()->Insert_ID();
+                }
 
                 // Create multilingual label name
                 $langValues = '';

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCustomField.php
@@ -57,7 +57,10 @@ class ProductCustomField extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('label', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
+        $builder->add('id_customization_field','Symfony\Component\Form\Extension\Core\Type\HiddenType', array(
+            'required' => false,
+        ))
+        ->add('label', 'PrestaShopBundle\Form\Admin\Type\TranslateType', array(
             'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
             'options' => [ 'constraints' => array(
                 new Assert\NotBlank(),

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -589,6 +589,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
 
         foreach ($customizationFields as $customizationField) {
             $baseObject = [
+                'id_customization_field' => $customizationField[$this->locales[0]['id_lang']]['id_customization_field'],
                 'label' => [],
                 'type' => $customizationField[$this->locales[0]['id_lang']]['type'],
                 'require' => $customizationField[$this->locales[0]['id_lang']]['required'] == 1 ? true : false,

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_custom_fields.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/Include/form_custom_fields.html.twig
@@ -23,6 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *#}
 <div class="row">
+    {{ form_widget(form.id_customization_field) }}
   <div class="col-md-3">
     <fieldset class="form-group">
       <label class="form-control-label">{{ form.label.vars.label }}</label>


### PR DESCRIPTION
In the new version of PrestaShop, all the customisation fields where
recreated at each product save, thus leading to missing labels in order
details (http://forge.prestashop.com/browse/BOOM-1395)